### PR TITLE
fix: Simplify release workflow by removing Python steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,6 @@ jobs:
           path: docs/site
       - uses: actions/deploy-pages@v4
             
-      - uses: actions/configure-pages@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.x
-      - run: pip install zensical
-        working-directory: docs
-      - run: zensical build --clean
-        working-directory: docs
-      - uses: actions/upload-pages-artifact@v4
-        with:
-          path: docs/site
-      - uses: actions/deploy-pages@v4
-            
       - name: Prepare release artifacts
         run: |
           mkdir -p release-artifacts


### PR DESCRIPTION
Removed unnecessary steps for Python setup and Zensical build in the release workflow.